### PR TITLE
Fix bind address substitution for newer nextjs version

### DIFF
--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -66,7 +66,7 @@ jobs:
           NEXT_PRIVATE_STANDALONE=1 yarn build
           # Allow overriding bind address using VHOSTIP or HOSTNAME environment variables
           sed -i '/server.listen(currentPort, (err) => {/c\server.listen(currentPort, process.env.HOSTNAME || process.env.VHOSTIP || "0.0.0.0", (err) => {' .next/standalone/server.js
-          # For newer versions of next, we need to override the bind address differently
+          # For newer versions of next, we need to override the bind address differently (HOSTNAME is now also supported by default)
           sed -i 's/process.env.HOSTNAME ||/process.env.VHOSTIP || process.env.HOSTNAME ||/g' .next/standalone/server.js
           # add http-graceful-shutdown and health check if exists
           [ -d ./node_modules/http-graceful-shutdown ] && echo "" >> .next/standalone/server.js

--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -67,7 +67,7 @@ jobs:
           # Allow overriding bind address using VHOSTIP or HOSTNAME environment variables
           sed -i '/server.listen(currentPort, (err) => {/c\server.listen(currentPort, process.env.HOSTNAME || process.env.VHOSTIP || "0.0.0.0", (err) => {' .next/standalone/server.js
           # For newer versions of next, we need to override the bind address differently
-          sed -i '/const hostname = process.env.HOSTNAME || \'localhost\'/c\const hostname = process.env.HOSTNAME || process.env.VHOSTIP || \'localhost\'' .next/standalone/server.js
+          sed -i 's/process.env.HOSTNAME ||/process.env.VHOSTIP || process.env.HOSTNAME ||/g' .next/standalone/server.js
           # add http-graceful-shutdown and health check if exists
           [ -d ./node_modules/http-graceful-shutdown ] && echo "" >> .next/standalone/server.js
           [ -d ./node_modules/http-graceful-shutdown ] && echo "require('http-graceful-shutdown')(server)" >> .next/standalone/server.js

--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -64,7 +64,10 @@ jobs:
         run: |
           echo $(node -v)
           NEXT_PRIVATE_STANDALONE=1 yarn build
-          sed -i '/server.listen(currentPort, (err) => {/c\server.listen(currentPort, process.env.VHOSTIP || "0.0.0.0", (err) => {' .next/standalone/server.js
+          # Allow overriding bind address using VHOSTIP or HOSTNAME environment variables
+          sed -i '/server.listen(currentPort, (err) => {/c\server.listen(currentPort, process.env.HOSTNAME || process.env.VHOSTIP || "0.0.0.0", (err) => {' .next/standalone/server.js
+          # For newer versions of next, we need to override the bind address differently
+          sed -i '/const hostname = process.env.HOSTNAME || \'localhost\'/c\const hostname = process.env.HOSTNAME || process.env.VHOSTIP || \'localhost\'' .next/standalone/server.js
           # add http-graceful-shutdown and health check if exists
           [ -d ./node_modules/http-graceful-shutdown ] && echo "" >> .next/standalone/server.js
           [ -d ./node_modules/http-graceful-shutdown ] && echo "require('http-graceful-shutdown')(server)" >> .next/standalone/server.js


### PR DESCRIPTION
Newer versions of nextjs generate a standalone `server.js` that already allows overriding through the `HOSTNAME` variable just like `PORT`, but for backward compatibility (and out-of-the box support for MageHost envs) it would be nice to maintain support for the `VHOSTIP` variable as well