### PR TITLE
fix: upgrade default nodeVersion to resolve annotation warnings in Github action workflows

### DIFF
--- a/.github/workflows/standalone-activate-artifact.yml
+++ b/.github/workflows/standalone-activate-artifact.yml
@@ -30,7 +30,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: deployment-artifact
       - name: Upload to server

--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -26,7 +26,7 @@ on:
         description: Version of node used by yarn to build the application
         type: string
         required: false
-        default: '16'
+        default: '20'
       limitSsg:
         description: Limit static site generation
         type: boolean

--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -108,7 +108,7 @@ jobs:
         run: echo "$(node -v)"
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: deployment-artifact
           path: ${{ github.sha }}_${{ inputs.applicationSuffixId }}.tar.gz

--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -9,7 +9,7 @@ on:
         description: Override for which file to use for ecosystem.config.js
         type: string
         required: false
-        default: "ecosystem.config.js"
+        default: 'ecosystem.config.js'
       applicationSuffixId:
         description: Suffix id for the application (set to 1 for 1st application, 2 for 2nd, etc)
         type: string
@@ -26,7 +26,7 @@ on:
         description: Version of node used by yarn to build the application
         type: string
         required: false
-        default: "16"
+        default: '16'
       limitSsg:
         description: Limit static site generation
         type: boolean
@@ -36,12 +36,12 @@ on:
         description: Reference to use in checkout (see 'ref' parameter in https://github.com/actions/checkout)
         type: string
         required: false
-        default: ""
+        default: ''
       runner:
         description: Github Action runner to use. Defaults to 'ubuntu-latest'
         type: string
         required: false
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
 
 jobs:
   build-artifact:
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.nodeVersion }}
-          cache: "yarn"
+          cache: 'yarn'
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/standalone-build-artifact.yml
+++ b/.github/workflows/standalone-build-artifact.yml
@@ -49,16 +49,16 @@ jobs:
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.4
         with:
           ref: ${{ inputs.checkoutRef }}
       - name: Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: 'yarn'
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Node 16 has reached its **end of life**. 

So we need to upgrade the following actions to upgrade from Node 16 to 20:
- "actions/download-artifact"
- "actions/upload-artifact"
- "actions/checkout"
- "actions/setup-node"
- "actions/cache"

![image](https://github.com/ho-nl/graphcommerce-deployment-workflows/assets/62989724/c909bc86-ea89-4330-a3cf-3add559de727)

source: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.