### PR TITLE
fix: replace scp-action with rsync to fix EOF error on large file upl…

### DIFF
--- a/.github/workflows/standalone-activate-artifact.yml
+++ b/.github/workflows/standalone-activate-artifact.yml
@@ -35,14 +35,15 @@ jobs:
         with:
           name: deployment-artifact-${{ inputs.applicationSuffixId }}
       - name: Upload to server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ inputs.serverHost }}
-          username: ${{ inputs.serverUser }}
-          key: ${{ secrets.SSH_KEY }}
-          port: ${{ inputs.serverPort }}
-          source: ${{ github.sha }}_${{ inputs.applicationSuffixId }}.tar.gz
-          target: ${{ inputs.deployTo }}./artifacts
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          echo "$SSH_KEY" > /tmp/deploy_key
+          chmod 600 /tmp/deploy_key
+          trap 'rm -f /tmp/deploy_key' EXIT
+          rsync -avz --progress -e "ssh -p ${{ inputs.serverPort }} -i /tmp/deploy_key -o StrictHostKeyChecking=no" \
+            "${{ github.sha }}_${{ inputs.applicationSuffixId }}.tar.gz" \
+            "${{ inputs.serverUser }}@${{ inputs.serverHost }}:${{ inputs.deployTo }}./artifacts/"
       - name: Node version
         run: echo "$(node -v)"
         shell: bash


### PR DESCRIPTION
…oads

Switched from appleboy/scp-action (drone-scp) to native rsync over SSH. drone-scp has a known EOF bug with large payloads. Added trap for key cleanup.