### PR TITLE
feat(runner): add runner input to activate workflows

### DIFF
--- a/.github/workflows/standalone-activate-artifact.yml
+++ b/.github/workflows/standalone-activate-artifact.yml
@@ -23,11 +23,16 @@ on:
       serverUser:
         type: string
         required: true
+      runner:
+        description: Github Action runner to use. Defaults to 'ubuntu-latest'
+        type: string
+        required: false
+        default: "ubuntu-latest"
 
 jobs:
   activate-artifact:
     name: Upload and activate artifact
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact

--- a/.github/workflows/standalone-activate-pm2.yml
+++ b/.github/workflows/standalone-activate-pm2.yml
@@ -48,11 +48,16 @@ on:
         type: string
         required: false
         default: '/data/web/.npm/bin/'
+      runner:
+        description: Github Action runner to use. Defaults to 'ubuntu-latest'
+        type: string
+        required: false
+        default: "ubuntu-latest"
 
 jobs:
   activate-applications:
     name: Activate applications
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}
     steps:
       - name: Activate


### PR DESCRIPTION
Add optional runner input (default: ubuntu-latest) to standalone-activate-artifact and standalone-activate-pm2 workflows, consistent with standalone-build-artifact.